### PR TITLE
Implement consumable item usage and inventory tests

### DIFF
--- a/mythic_depths/entities/player.py
+++ b/mythic_depths/entities/player.py
@@ -12,8 +12,9 @@ class Player:
         tile_size (int): Size of the player's tile.
         speed (int): Movement speed of the player.
         name (str): Name of the player.
-        health (int): Health points of the player.
+        health (int): Maximum health points of the player.
         strength (int): Strength attribute of the player.
+        mana (int): Maximum mana points of the player.
         inventory (Inventory): The player's inventory.
     """
 
@@ -21,15 +22,39 @@ class Player:
                  name: str = 'Fella',
                  health: int = 100,
                  strength: int = 10,
+                 mana: int = 50,
                  tile_size: int = 20):
         self.x = x
         self.y = y
         self.tile_size = tile_size
         self.speed = self.tile_size // 4
         self.name = name
-        self.health = health
+        self.max_health = max(0, health)
+        self.health = self.max_health
         self.strength = strength
+        self.max_mana = max(0, mana)
+        self.mana = self.max_mana
         self.inventory = Inventory()
+
+    # ------------------------------------------------------------------
+    # Basic stat helpers
+    def restore_health(self, amount: int) -> int:
+        """Restore up to ``amount`` health and return the amount healed."""
+
+        if amount <= 0 or self.max_health == 0:
+            return 0
+        previous = self.health
+        self.health = min(self.max_health, self.health + amount)
+        return self.health - previous
+
+    def restore_mana(self, amount: int) -> int:
+        """Restore up to ``amount`` mana and return the amount recovered."""
+
+        if amount <= 0 or self.max_mana == 0:
+            return 0
+        previous = self.mana
+        self.mana = min(self.max_mana, self.mana + amount)
+        return self.mana - previous
 
     def move(self, dx, dy, dungeon):
         """

--- a/mythic_depths/systems/inventory.py
+++ b/mythic_depths/systems/inventory.py
@@ -1,23 +1,75 @@
-from mythic_depths.config.config import TILE_SIZE
-from mythic_depths.systems import items
+from __future__ import annotations
+
+from typing import Dict
+
+from mythic_depths.systems.items import ITEM_REGISTRY, Item, create_item
 
 
 class Inventory:
-    """
-    Manages the player's inventory of items.
-
-    Attributes:
-        items (dict): A dictionary of item names and their quantities.
-    """
+    """A small helper that tracks and consumes items for the player."""
 
     def __init__(self):
-        self.items = {}
+        self._items: Dict[str, int] = {}
 
-    def add_item(self, item):
-        """
-        Add an item to the inventory.
+    # ------------------------------------------------------------------
+    # Management helpers
+    def add_item(self, item: Item, quantity: int = 1) -> None:
+        """Add ``quantity`` copies of ``item`` to the inventory."""
 
-        Args:
-            item: The item to add.
+        if quantity <= 0:
+            raise ValueError("quantity must be positive")
+        self._items[item.name] = self._items.get(item.name, 0) + quantity
+
+    def remove_item(self, item_name: str, quantity: int = 1) -> None:
+        """Remove ``quantity`` items from the inventory.
+
+        Raises ``KeyError`` if the item is missing or there are not enough
+        copies to remove.
         """
-        self.items[item.name] = self.items.get(item.name, 0) + 1
+
+        if quantity <= 0:
+            raise ValueError("quantity must be positive")
+        current = self._items.get(item_name)
+        if current is None or current < quantity:
+            raise KeyError(f"Not enough '{item_name}' in inventory")
+        remaining = current - quantity
+        if remaining:
+            self._items[item_name] = remaining
+        else:
+            del self._items[item_name]
+
+    def get_quantity(self, item_name: str) -> int:
+        """Return how many copies of ``item_name`` are stored."""
+
+        return self._items.get(item_name, 0)
+
+    def items(self):
+        """Iterate over ``(name, quantity)`` pairs stored in the inventory."""
+
+        return self._items.items()
+
+    # ------------------------------------------------------------------
+    # Gameplay helpers
+    def can_use(self, item_name: str) -> bool:
+        """Check whether ``item_name`` exists and has an associated effect."""
+
+        return item_name in self._items and item_name in ITEM_REGISTRY
+
+    def use_item(self, item_name: str, player) -> int:
+        """Consume an item, applying its effect to ``player``.
+
+        Returns the result of ``Item.use`` so callers can react to the amount
+        healed/restored. A return value of ``0`` indicates that no effect took
+        place, either because the player was already at maximum capacity or
+        because the item has no implemented behaviour.
+        """
+
+        if not self.can_use(item_name):
+            return 0
+
+        item = create_item(item_name)
+        effect = item.use(player)
+        # Only remove the item if an effect actually happened.
+        if effect > 0:
+            self.remove_item(item_name)
+        return effect

--- a/mythic_depths/systems/items.py
+++ b/mythic_depths/systems/items.py
@@ -1,21 +1,65 @@
 # Here is where you can implement item attributes from `items.json`
 
-class Item:
-    """Base class for items."""
+from __future__ import annotations
 
-    def __init__(self, name):
-        self.name = name
+from typing import Dict, Type
+
+
+class Item:
+    """Base class for consumable items."""
+
+    #: Default amount restored or applied when the item is consumed.
+    amount: int = 0
+    #: Human readable name. Sub-classes should override this.
+    name: str = "Generic Item"
+    #: Short flavour description that can be surfaced in UI tooling later.
+    description: str = ""
+
+    def use(self, player) -> int:
+        """Apply the item's effect to the provided ``player``.
+
+        The default implementation performs no action and returns ``0`` to
+        indicate that nothing happened. Sub-classes should override this
+        method and return the effective amount of healing/energy granted so
+        that higher level systems (UI, logging, etc.) can report the outcome.
+        """
+
+        return 0
 
 
 class HealthPotion(Item):
-    """Restores player health."""
+    """Restore a chunk of the player's health."""
 
-    def __init__(self):
-        super().__init__("Health Potion")
+    name = "Health Potion"
+    amount = 30
+    description = "A soothing tonic that closes wounds and restores vitality."
+
+    def use(self, player) -> int:
+        return player.restore_health(self.amount)
 
 
 class ArcanePotion(Item):
-    """Restores player magic."""
+    """Restore a chunk of the player's mana pool."""
 
-    def __init__(self):
-        super().__init__("Arcane Potion")
+    name = "Arcane Potion"
+    amount = 20
+    description = "A swirling elixir that rekindles the drinker's mana."
+
+    def use(self, player) -> int:
+        return player.restore_mana(self.amount)
+
+
+ITEM_REGISTRY: Dict[str, Type[Item]] = {
+    HealthPotion.name: HealthPotion,
+    ArcanePotion.name: ArcanePotion,
+}
+
+
+def create_item(name: str) -> Item:
+    """Factory helper that instantiates the item associated with ``name``.
+
+    Raises ``KeyError`` if the item has not been registered yet.
+    """
+
+    item_cls = ITEM_REGISTRY[name]
+    return item_cls()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration shared across the suite."""
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,56 @@
+import pytest
+
+from mythic_depths.entities.player import Player
+from mythic_depths.systems.items import ArcanePotion, HealthPotion
+
+
+def test_health_potion_consumption_reduces_inventory():
+    player = Player(0, 0, health=80, mana=40)
+    player.health = 30
+
+    inventory = player.inventory
+    inventory.add_item(HealthPotion())
+
+    healed = inventory.use_item(HealthPotion.name, player)
+
+    assert healed == 30
+    assert player.health == 60
+    assert inventory.get_quantity(HealthPotion.name) == 0
+
+
+def test_arcane_potion_restores_only_missing_mana():
+    player = Player(0, 0, health=100, mana=50)
+    player.mana = 45
+
+    inventory = player.inventory
+    inventory.add_item(ArcanePotion())
+
+    restored = inventory.use_item(ArcanePotion.name, player)
+
+    assert restored == 5
+    assert player.mana == 50
+    assert inventory.get_quantity(ArcanePotion.name) == 0
+
+
+def test_consuming_at_full_health_keeps_item():
+    player = Player(0, 0, health=60, mana=20)
+
+    inventory = player.inventory
+    inventory.add_item(HealthPotion())
+
+    healed = inventory.use_item(HealthPotion.name, player)
+
+    assert healed == 0
+    assert inventory.get_quantity(HealthPotion.name) == 1
+
+
+def test_remove_item_validates_quantity():
+    player = Player(0, 0)
+    inventory = player.inventory
+    inventory.add_item(HealthPotion())
+
+    with pytest.raises(KeyError):
+        inventory.remove_item(HealthPotion.name, quantity=2)
+
+    with pytest.raises(ValueError):
+        inventory.remove_item(HealthPotion.name, quantity=0)


### PR DESCRIPTION
## Summary
- add consumable item behaviours with a registry and factory for potions
- extend the player and inventory systems to support healing and mana restoration
- add inventory-focused unit tests and ensure pytest can import the package

## Testing
- pytest tests/test_inventory.py

------
https://chatgpt.com/codex/tasks/task_e_68daed44405083249e3e65b48d5cbc72